### PR TITLE
Handle missing NPCs in world

### DIFF
--- a/core/world.py
+++ b/core/world.py
@@ -22,8 +22,11 @@ class World:
         self.agents.append(agent)
 
     def get_nearest_npc(self, agent):
+        others = [other for other in self.agents if other != agent]
+        if not others:
+            return None
         return min(
-            (other for other in self.agents if other != agent),
+            others,
             key=lambda other: self.calculate_distance(agent.position, other.position),
         )
 

--- a/main.py
+++ b/main.py
@@ -6,19 +6,29 @@ from agents.inner_thought_generator import InnerThoughtGenerator
 from core.setup.agent_builder import AgentBuilder
 from core.setup.world_builder import WorldBuilder
 from models.local_model import LocalModel
+from core.logger import setup_logger
 
 
 def run_agent():
 
+    logger = setup_logger(__name__)
+
     model = LocalModel()
     perception = Perception(model)
-    
+
     planner = ModularPlanner(model)
-    
+
     world = WorldBuilder().setup_medieval_village_world()
     agents = AgentBuilder(InnerThoughtGenerator(model), EventTripleGenerator(model)).build_medieval_agents()
     for agent in agents:
         world.add_agent(agent)
+
+        nearest = world.get_nearest_npc(agent)
+        if nearest is None:
+            logger.debug(f"No nearby agents for {agent.name} to interact with.")
+        else:
+            logger.debug(f"Nearest agent to {agent.name} is {nearest.name}.")
+
         retrieval = Retrieval(agent.long_term_memory, agent.short_term_memory)
         perceived = perception.perceive(agent, world)
         retrieved = retrieval.retrieve_context(perceived)


### PR DESCRIPTION
## Summary
- Safeguard `World.get_nearest_npc` to return `None` when no other agents are present
- Log when no nearby agent exists in `run_agent`

## Testing
- `python -m py_compile core/world.py main.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bdec491f048321979d8fbde8c67c00