### PR TITLE
Allow LocalModel to read model path from environment variable

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,6 +10,9 @@ from models.local_model import LocalModel
 
 def run_agent():
 
+    # The model path can be passed explicitly or set via the MODEL_PATH
+    # environment variable before running this script.
+    # model = LocalModel("/path/to/model.gguf")
     model = LocalModel()
     perception = Perception(model)
     

--- a/main.py
+++ b/main.py
@@ -10,7 +10,6 @@ from models.local_model import LocalModel
 
 def run_agent():
 
-    # model = LocalModel("/path/to/model.gguf")
     model = LocalModel()
     perception = Perception(model)
     

--- a/main.py
+++ b/main.py
@@ -10,8 +10,6 @@ from models.local_model import LocalModel
 
 def run_agent():
 
-    # The model path can be passed explicitly or set via the MODEL_PATH
-    # environment variable before running this script.
     # model = LocalModel("/path/to/model.gguf")
     model = LocalModel()
     perception = Perception(model)

--- a/models/local_model.py
+++ b/models/local_model.py
@@ -7,15 +7,29 @@ from core.logger import setup_logger
 logger = setup_logger(__name__)
 
 class LocalModel:
-    def __init__(self, model_path: str = "/Users/adittrich/privat/mistral-7b-instruct-v0.1.Q4_K_M.gguf"): # ToDo: make configureable
-        if not os.path.exists(model_path):
-            raise FileNotFoundError(f"LLM model not found at: {model_path}")
-        
+    """Thin wrapper around :class:`llama_cpp.Llama`.
+
+    The model path can be supplied directly or set via the ``MODEL_PATH``
+    environment variable.
+
+    Examples
+    --------
+    >>> LocalModel("/path/to/model.gguf")
+    >>> LocalModel()  # expects MODEL_PATH to be defined
+    """
+
+    def __init__(self, model_path: str | None = None) -> None:
+        model_path = model_path or os.environ.get("MODEL_PATH")
+        if not model_path or not os.path.exists(model_path):
+            raise FileNotFoundError(
+                f"LLM model not found at: {model_path}. Set MODEL_PATH or pass a valid path."
+            )
+
         self.llm = Llama(
             model_path=model_path,
             n_ctx=2048,
-            n_threads=4,    # ToDo: make configureable: adjust to your CPU
-            verbose=False
+            n_threads=4,  # ToDo: make configureable: adjust to your CPU
+            verbose=False,
         )
 
     def generate(self, prompt: str, max_tokens: int = 256, stop: list = None) -> str:


### PR DESCRIPTION
## Summary
- let `LocalModel` resolve the model path from an argument or `MODEL_PATH`
- clarify error message when model file is missing
- document model path usage in `main.py`

## Testing
- `python -m py_compile models/local_model.py main.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bdec409c6083219bfeb949a0db7255